### PR TITLE
Improve stock table readability with new CSS styles

### DIFF
--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -123,28 +123,30 @@ string html(string tableBody) => @$"<!doctype html>
 
 string css() => @"
 body {
-    font-family: sans-serif;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; /* Corporate font */
     font-size: large;
 }
 table {
     width: 100%;
     border-collapse: collapse;
-    font-family: 'Aial', sans-serif; /* Modern font */
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; /* Corporate font */
     font-size: 16px; /* Increase font size */
+    color: #333; /* Corporate text color */
 }
 table tr:nth-child(even) {
-    background-color: #f2f2f2; /* Alternating row colors */
+    background-color: #f9f9f9; /* Light grey for alternating rows */
 }
 table th, table td {
     padding: 12px; /* Add padding to table cells */
     text-align: center; /* Center-align table headers */
+    border: 1px solid #ddd; /* Light grey border */
 }
 table th {
-    background-color: #4CAF50;
-    color: white;
+    background-color: #004080; /* Corporate blue background */
+    color: white; /* White text color */
 }
 table tr:hover {
-    background-color: #ddd; /* Hover effect */
+    background-color: #e6f2ff; /* Light blue hover effect */
 }";
 
 [JsonSerializable(typeof(Dictionary<string, string[]>))]

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -127,18 +127,24 @@ body {
     font-size: large;
 }
 table {
+    width: 100%;
     border-collapse: collapse;
-    border: 1px solid #ccc;
-    font-family: monospace;
+    font-family: 'Arial', sans-serif; /* Modern font */
+    font-size: 16px; /* Increase font size */
 }
-th, td {
-    text-align: right;
-    font-variant-numeric: tabular-nums;
-    padding: 8px;
-    border: 1px solid #ccc;
+table tr:nth-child(even) {
+    background-color: #f2f2f2; /* Alternating row colors */
 }
-table tr td:first-child, table tr th:first-child {
-    text-align: left;
+table th, table td {
+    padding: 12px; /* Add padding to table cells */
+    text-align: center; /* Center-align table headers */
+}
+table th {
+    background-color: #4CAF50;
+    color: white;
+}
+table tr:hover {
+    background-color: #ddd; /* Hover effect */
 }";
 
 [JsonSerializable(typeof(Dictionary<string, string[]>))]

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -129,7 +129,7 @@ body {
 table {
     width: 100%;
     border-collapse: collapse;
-    font-family: 'Arial', sans-serif; /* Modern font */
+    font-family: 'Aial', sans-serif; /* Modern font */
     font-size: 16px; /* Increase font size */
 }
 table tr:nth-child(even) {


### PR DESCRIPTION
This PR improves the readability of the stock table by adding alternating row colors, using a more modern font, increasing the font size, adding padding and margins to the table cells, center-aligning the table headers, and adding a hover effect to highlight rows when the mouse is over them.